### PR TITLE
backend:バーコード読み込みで商品情報を取り込む

### DIFF
--- a/.github/workflows/deploy_backend_review.yml
+++ b/.github/workflows/deploy_backend_review.yml
@@ -12,6 +12,7 @@ env:
   SERVICE_NAME: ${{ secrets.REVIEW_SERVICE_NAME }}
   DATABASE_URL: ${{ secrets.REVIEW_DATABASE_URL }}
   REVIEW_FIREBASE_SERVICE: ${{ secrets.REVIEW_FIREBASE_SERVICE }}
+  YAHOO_APP_ID: ${{ secrets.YAHOO_APP_ID }}
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -57,4 +58,4 @@ jobs:
             --region asia-northeast1 \
             --allow-unauthenticated \
             --service-account=github@$PROJECT_ID.iam.gserviceaccount.com \
-            --set-env-vars DATABASE_URL="$DATABASE_URL"
+            --set-env-vars DATABASE_URL="$DATABASE_URL",YAHOO_APP_ID="$YAHOO_APP_ID"

--- a/typescript/backend/src/app.module.ts
+++ b/typescript/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from '@src/app.service'
 import { HelloResolver } from './hello.resolver'
 import { CategoryResolver } from '@src/resolver/category'
 import { ItemResolver } from '@src/resolver/item'
+import { ItemFromQRResolver } from '@src/resolver/itemFromQR'
 import { UserResolver } from '@src/resolver/user'
 import { CartResolver } from '@src/resolver/cart'
 import { InviteResolver } from '@src/resolver/invite'
@@ -21,6 +22,7 @@ import { ConfigModule } from '@nestjs/config'
     UserResolver,
     CategoryResolver,
     ItemResolver,
+    ItemFromQRResolver,
     CartResolver,
     InviteResolver,
     GuestResolver,

--- a/typescript/backend/src/generated/graphql.ts
+++ b/typescript/backend/src/generated/graphql.ts
@@ -79,6 +79,16 @@ export type Item = {
   stock: Scalars['Int']['output'];
 };
 
+export type ItemFromQr = {
+  __typename?: 'ItemFromQR';
+  /** 画像URL */
+  imageURL?: Maybe<Scalars['String']['output']>;
+  /** 画像のリスト */
+  images?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /** アイテム名 */
+  name: Scalars['String']['output'];
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   addCarts: Scalars['Boolean']['output'];
@@ -183,6 +193,7 @@ export type Query = {
   invite?: Maybe<Invite>;
   item?: Maybe<Item>;
   itemAll?: Maybe<Array<Maybe<Item>>>;
+  itemFromQR?: Maybe<ItemFromQr>;
   items?: Maybe<Array<Maybe<Item>>>;
   me?: Maybe<User>;
 };
@@ -195,6 +206,11 @@ export type QueryCategoryArgs = {
 
 export type QueryItemArgs = {
   id: Scalars['Int']['input'];
+};
+
+
+export type QueryItemFromQrArgs = {
+  janCode: Scalars['String']['input'];
 };
 
 

--- a/typescript/backend/src/lib/shopping.ts
+++ b/typescript/backend/src/lib/shopping.ts
@@ -1,0 +1,50 @@
+type Hit = {
+  index: number
+  name: string
+  exImage: {
+    url: string
+  }
+}
+
+type SearchResult = {
+  totalResultsAvailable: number
+  totalResultsReturned: number
+  firstResultsPosition: number
+  request: Request
+  hits: Hit[]
+}
+
+const IMAGE_SIZE = 300
+
+type ShoppingItem = {
+  name: string
+  imageURL: string
+  images: string[]
+}
+
+export const getShoppingItem = async (
+  janCode: string
+): Promise<ShoppingItem | null> => {
+  const response = await fetch(
+    `https://shopping.yahooapis.jp/ShoppingWebService/V3/itemSearch?appid=${process.env.YAHOO_APP_ID}&jan_code=${janCode}&image_size=${IMAGE_SIZE}`
+  )
+  if (!response.ok) {
+    return null
+  }
+  const data: SearchResult = await response.json()
+
+  if (data.totalResultsReturned === 0) {
+    return null
+  }
+
+  const hit = data.hits[0]
+  const images = data.hits.map((hit) => hit.exImage.url)
+
+  const shoppingItem: ShoppingItem = {
+    name: hit.name,
+    imageURL: hit.exImage.url,
+    images,
+  }
+
+  return shoppingItem
+}

--- a/typescript/backend/src/resolver/itemFromQR.ts
+++ b/typescript/backend/src/resolver/itemFromQR.ts
@@ -1,0 +1,21 @@
+import { Resolver, Query, Args } from '@nestjs/graphql'
+import { UseGuards } from '@nestjs/common'
+import type { Query as QueryType } from '@src/generated/graphql'
+import { PrismaService } from '@src/modules/prisma/prisma.service'
+import { AuthGuard } from '@src/common/guards/auth/auth.guard'
+import { getShoppingItem } from '@src/lib/shopping'
+
+@Resolver('')
+export class ItemFromQRResolver {
+  constructor(private prisma: PrismaService) {}
+
+  @Query('itemFromQR')
+  @UseGuards(AuthGuard)
+  async items(
+    @Args('janCode') janCode: string
+  ): Promise<QueryType['itemFromQR']> {
+    const item = await getShoppingItem(janCode)
+
+    return item
+  }
+}

--- a/typescript/backend/src/schema.graphql
+++ b/typescript/backend/src/schema.graphql
@@ -4,6 +4,7 @@ type Query {
   category(id: Int!): Category
   items(categoryId: Int!): [Item]
   item(id: Int!): Item
+  itemFromQR(janCode: String!): ItemFromQR
   me: User
   itemAll: [Item]
   carts: [Cart]
@@ -47,6 +48,15 @@ type Item {
   order: Int!
   "カテゴリー"
   category: Category
+}
+
+type ItemFromQR {
+  "アイテム名"
+  name: String!
+  "画像URL"
+  imageURL: String
+  "画像のリスト"
+  images: [String]
 }
 
 type Cart {

--- a/typescript/tools/getIdToken/main.ts
+++ b/typescript/tools/getIdToken/main.ts
@@ -1,39 +1,39 @@
-import admin from 'firebase-admin'
-import { initializeApp } from 'firebase/app'
-import { getAuth, signInWithEmailAndPassword } from 'firebase/auth'
-import clipboardy from 'clipboardy'
-import * as dotenv from 'dotenv'
+import admin from "firebase-admin";
+import { initializeApp } from "firebase/app";
+import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
+import clipboardy from "clipboardy";
+import * as dotenv from "dotenv";
 
 // 環境変数の読み込み
-dotenv.config()
+dotenv.config();
 
 // Firebaseプロジェクトの設定
-import serviceAccount from './firebase.json' assert { type: 'json' }
+import serviceAccount from "./firebase.json" assert { type: "json" };
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount as admin.ServiceAccount),
-})
+});
 
 // Firebase Admin SDKの初期化
 const app = initializeApp({
   apiKey: process.env.FIREBASE_API_KEY,
   authDomain: process.env.FIREBASE_AUTH_DOMAIN,
-})
+});
 
 // コマンドライン引数からメールアドレスとパスワードを取得
-const email = process.env.USER_EMAIL as string
-const password = process.env.USER_PASSWORD as string
+const email = process.env.USER_EMAIL as string;
+const password = process.env.USER_PASSWORD as string;
 
 // Firebase Authentication にログイン
-const auth = getAuth(app)
+const auth = getAuth(app);
 signInWithEmailAndPassword(auth, email, password)
   .then((userCredential) => {
-    return userCredential.user.getIdToken()
+    return userCredential.user.getIdToken();
   })
   .then((idToken) => {
-    console.log('ID Token:', idToken)
-    clipboardy.writeSync(idToken)
+    console.log("ID Token: Bearer", idToken);
+    clipboardy.writeSync(`Bearer ${idToken}`);
   })
   .catch((error) => {
-    console.error('認証エラー:', error.message)
-  })
+    console.error("認証エラー:", error.message);
+  });


### PR DESCRIPTION
## issue

 - #71

## 対応内容


 - GraphQLにitemFromQRを追加
 - variablesのjan_codeを使って[商品検索（v3） - Yahoo!デベロッパーネットワーク](https://developer.yahoo.co.jp/webapi/shopping/v3/itemsearch.html)のAPIを使用して名前と画像のURLを取得する